### PR TITLE
Xendit #0000 - Add documentation to Rides API

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1814,6 +1814,19 @@
         "has-flag": "^3.0.0"
       }
     },
+    "swagger-ui-dist": {
+      "version": "3.36.0",
+      "resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-3.36.0.tgz",
+      "integrity": "sha512-y+ZTvI5vU1xnb2TtUk6JctoCyDDnjXWdpxJbE3BAd7wOXa8vdwNND4suJIpIRffxRygoZw42z3qGWjRK+xqfJA=="
+    },
+    "swagger-ui-express": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/swagger-ui-express/-/swagger-ui-express-4.1.4.tgz",
+      "integrity": "sha512-Ea96ecpC+Iq9GUqkeD/LFR32xSs8gYqmTW1gXCuKg81c26WV6ZC2FsBSPVExQP6WkyUuz5HEiR0sEv/HCC343g==",
+      "requires": {
+        "swagger-ui-dist": "^3.18.1"
+      }
+    },
     "tar": {
       "version": "4.4.8",
       "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.8.tgz",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
   "dependencies": {
     "body-parser": "^1.19.0",
     "express": "^4.16.4",
-    "sqlite3": "^4.0.6"
+    "sqlite3": "^4.0.6",
+    "swagger-ui-express": "^4.1.4"
   },
   "devDependencies": {
     "mocha": "^6.1.4",

--- a/src/app.js
+++ b/src/app.js
@@ -6,8 +6,13 @@ const app = express();
 const bodyParser = require('body-parser');
 const jsonParser = bodyParser.json();
 
+const swaggerUI = require('swagger-ui-express');
+const swaggerFile = require('./resources/api-v1-swagger.json');
+
 module.exports = (db) => {
     app.get('/health', (req, res) => res.send('Healthy'));
+
+    app.use('/api-documentation/v1', swaggerUI.serve, swaggerUI.setup(swaggerFile));
 
     app.post('/rides', jsonParser, (req, res) => {
         const startLatitude = Number(req.body.start_lat);

--- a/src/resources/api-v1-swagger.json
+++ b/src/resources/api-v1-swagger.json
@@ -1,0 +1,217 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "description": "Backend API for rides",
+    "version": "1.0.0",
+    "title": "Rides",
+    "contact": {
+      "email": "jimenez.johnjoshua.jjj@gmail.com"
+    }
+  },
+  "definitions": {
+    "RideOutput": {
+      "type": "object",
+      "required": [
+        "startLat",
+        "startLong",
+        "endLat",
+        "endLong",
+        "riderName",
+        "driverName",
+        "driverVehicle"
+      ],
+      "properties": {
+        "rideID": {
+          "type": "integer",
+          "example": 1
+        },
+        "startLat": {
+          "type": "integer",
+          "minimum": -90,
+          "maximum": 90,
+          "example": 90
+        },
+        "startLong": {
+          "type": "integer",
+          "minimum": -180,
+          "maximum": 180,
+          "example": 180
+        },
+        "endLat": {
+          "type": "integer",
+          "minimum": -90,
+          "maximum": 90,
+          "example": -90
+        },
+        "endLong": {
+          "type": "integer",
+          "minimum": -180,
+          "maximum": 180,
+          "example": -180
+        },
+        "riderName": {
+          "type": "string",
+          "example": "Joshua"
+        },
+        "driverName": {
+          "type": "string",
+          "example": "John"
+        },
+        "driverVehicle": {
+          "type": "string",
+          "example": "Truck"
+        },
+        "created": {
+          "type": "string",
+          "example": "2020-10-27 13:23:33"
+        }
+      }
+    },
+    "RideInput": {
+      "type": "object",
+      "required": [
+        "start_lat",
+        "start_long",
+        "end_lat",
+        "end_long",
+        "rider_name",
+        "driver_name",
+        "driver_vehicle"
+      ],
+      "properties": {
+        "start_lat": {
+          "type": "integer",
+          "minimum": -90,
+          "maximum": 90,
+          "example": 90
+        },
+        "start_long": {
+          "type": "integer",
+          "minimum": -180,
+          "maximum": 180,
+          "example": 180
+        },
+        "end_lat": {
+          "type": "integer",
+          "minimum": -90,
+          "maximum": 90,
+          "example": -90
+        },
+        "end_long": {
+          "type": "integer",
+          "minimum": -180,
+          "maximum": 180,
+          "example": -180
+        },
+        "rider_name": {
+          "type": "string",
+          "example": "Joshua"
+        },
+        "driver_name": {
+          "type": "string",
+          "example": "John"
+        },
+        "driver_vehicle": {
+          "type": "string",
+          "example": "Truck"
+        }
+      }
+    }
+  },
+  "paths": {
+    "/health": {
+      "get": {
+        "summary": "Health check endpoint for the server",
+        "description": "Checks if the server is running",
+        "operationId": "healthcheck",
+        "responses": {
+          "200": {
+            "description": "Server is up and running"
+          }
+        }
+      }
+    },
+
+    "/rides": {
+      "get": {
+        "summary": "Get all saved rides",
+        "description": "Get all saved rides",
+        "produces": [
+          "application/json"
+        ],
+        "operationId": "getRides",
+        "responses": {
+          "200": {
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/RideOutput"
+              }
+            },
+            "description": "Successful operation"
+          }
+        }
+      },
+      "post": {
+        "summary": "Add a new ride",
+        "description": "Add a new ride",
+        "operationId": "addRide",
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "body",
+            "name": "body",
+            "description": "Rider object that needs to be added",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/RideInput"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successfully added new ride"
+          }
+        }
+      }
+    },
+
+    "/rides/{rideId}": {
+      "get": {
+        "summary": "Get saved ride by id",
+        "description": "Get saved ride by id",
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "rideId",
+            "in": "path",
+            "description": "ID of ride to return",
+            "required": true,
+            "type": "integer"
+          }
+        ],
+        "operationId": "getRideById",
+        "responses": {
+          "200": {
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/RideOutput"
+              }
+            },
+            "description": "Successful operation"
+          }
+        }
+      }
+    }
+  },
+  "host": "localhost:8010",
+  "basePath": "/"
+}


### PR DESCRIPTION
**Background**
> Please deliver documentation of the server that clearly explains the goals of this project and clarifies the API response that is expected.

**Acceptance Criteria**
> 1. A pull request against `master` of your fork with a clear description of the change and purpose and merge it
> **[BONUS]** Create an easy way to deploy and view the documentation in a web format and include instructions to do so

**Description**
- The PR adds a swagger documentation for the Rides API, with a new dependency to **swagger-ui-express**
- Web documentation can be viewed with **/api-documentation/v1**. Upon API deployment, the documentation should also be available.
![image](https://user-images.githubusercontent.com/22243493/97312794-d73f0e80-18a0-11eb-8025-2a697f7f7a3d.png)
- The swagger file is prefixed with _api-v_ as to indicate the API version it is documenting, since it is possible to have multiple documentation support multiple versions of the API.

**Problems encountered**
The validation code we have returns a 200 success code on invalid POST requests to **/rides**, in which the more appropriate ones should be a **400** or **422**. This should be addressed with #4 Refactoring, as it hinders the documentation for possibly having multiple response bodies for the same status code, as well as removing the semantics for the status code.