### PR TITLE
Xendit #0004 - Improve test coverage

### DIFF
--- a/tests/api.test.js
+++ b/tests/api.test.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const request = require('supertest');
+const assert = require('assert');
 
 const sqlite3 = require('sqlite3').verbose();
 const db = new sqlite3.Database(':memory:');
@@ -8,25 +9,213 @@ const db = new sqlite3.Database(':memory:');
 const app = require('../src/app')(db);
 const buildSchemas = require('../src/schemas');
 
+const dummyRides = require('./resources/dummyRides.json');
+
+const assertRideEntity = (dummyRide, actualRide) => {
+  assert.strictEqual(actualRide.riderName, dummyRide.rider_name);
+  assert.strictEqual(actualRide.driverName, dummyRide.driver_name);
+  assert.strictEqual(actualRide.driverVehicle, dummyRide.driver_vehicle);
+  assert.strictEqual(actualRide.endLat, dummyRide.end_lat);
+  assert.strictEqual(actualRide.startLat, dummyRide.start_lat);
+  assert.strictEqual(actualRide.endLong, dummyRide.end_long);
+  assert.strictEqual(actualRide.startLong, dummyRide.start_long);
+};
+
+const assertRideValidationError = (propertiesToOverride, validationError, done) => {
+  const body = { ...dummyRides[2], ...propertiesToOverride };
+  request(app).
+      post('/rides').
+      send(body).
+      expect('Content-Type', /json/).
+      expect(200).
+      expect(validationError)
+      .end(done);
+};
+
 describe('API tests', () => {
-    before((done) => {
-        db.serialize((err) => { 
-            if (err) {
-                return done(err);
-            }
+  before((done) => {
+    db.serialize((err) => {
+      if (err) {
+        return done(err);
+      }
 
-            buildSchemas(db);
+      buildSchemas(db);
 
-            done();
+      done();
+    });
+  });
+
+  describe('GET /health', () => {
+    it('should return health', (done) => {
+      request(app).
+          get('/health').
+          expect('Content-Type', /text/).
+          expect(200, done);
+    });
+  });
+
+  describe('Ride endpoints', () => {
+    beforeEach((done) => {
+      db.serialize((err) => {
+        if (err) {
+          return done(err);
+        }
+        db.run('DELETE FROM Rides', () => {
+          const [dummyRideOne, dummyRideTwo] = dummyRides;
+          const insertQuery = 'INSERT INTO Rides(startLat, startLong, endLat,' +
+              ' endLong, riderName, driverName, driverVehicle) VALUES' +
+              ' (?, ?, ?, ?, ?, ?, ?)';
+          db.run(insertQuery, Object.values(dummyRideOne), () => {
+            db.run(insertQuery, Object.values(dummyRideTwo), () => {
+              db.run('UPDATE SQLITE_SEQUENCE SET SEQ=0 WHERE' +
+                  ' NAME=\'Rides\';\n', () => {
+                done();
+              });
+            });
+          });
         });
+      });
     });
 
-    describe('GET /health', () => {
-        it('should return health', (done) => {
-            request(app)
-                .get('/health')
-                .expect('Content-Type', /text/)
-                .expect(200, done);
-        });
+    describe('GET /rides', () => {
+      it('should return all rides', (done) => {
+        request(app).
+            get('/rides').
+            expect('Content-Type', /json/).
+            expect(200).
+            expect(response => {
+              const [ actualRideOne, actualRideTwo ] = response.body;
+              const [ dummyRideOne, dummyRideTwo ] = dummyRides;
+              assertRideEntity(dummyRideOne, actualRideOne);
+              assertRideEntity(dummyRideTwo, actualRideTwo);
+            })
+            .end(done);
+      });
     });
+
+    describe('GET /rides/${id}', () => {
+      it('should return ride id of 2', (done) => {
+        request(app).
+            get('/rides/2').
+            expect('Content-Type', /json/).
+            expect(200).
+            expect(response => {
+              const [ actualRideTwo ] = response.body;
+              const [ , dummyRideTwo ] = dummyRides;
+              assertRideEntity(dummyRideTwo, actualRideTwo);
+            })
+            .end(done);
+      });
+    });
+
+    describe('POST /rides', () => {
+      it('should create a new ride', (done) => {
+        const body = dummyRides[2];
+        request(app).
+            post('/rides').
+            send(body).
+            expect('Content-Type', /json/).
+            expect(200).
+            expect(response => {
+              const [ actualRide ] = response.body;
+              assertRideEntity(body, actualRide);
+            })
+            .end(done);
+      });
+
+      describe('validation errors for start latitude', () => {
+        const validationError = {
+          error_code: 'VALIDATION_ERROR',
+          message: 'Start latitude and longitude must be between -90 - 90 and -180 to 180 degrees respectively',
+        };
+
+        it('should give validation error for start latitude greater than 90', (done) => {
+          const propertyWithError = { start_lat: 91 };
+          assertRideValidationError(propertyWithError, validationError, done);
+        });
+
+        it('should give validation error for start latitude lower than -90', (done) => {
+          const propertyWithError = { start_lat: -91 };
+          assertRideValidationError(propertyWithError, validationError, done);
+        });
+      });
+
+      describe('validation errors for start longitude', () => {
+        const validationError = {
+          error_code: 'VALIDATION_ERROR',
+          message: 'Start latitude and longitude must be between -90 - 90 and -180 to 180 degrees respectively',
+        };
+
+        it('should give validation error for start longitude greater than 180', (done) => {
+          const propertyWithError = { start_long: 181 };
+          assertRideValidationError(propertyWithError, validationError, done);
+        });
+
+        it('should give validation error for start longitude lower than -180', (done) => {
+          const propertyWithError = { start_long: -181 };
+          assertRideValidationError(propertyWithError, validationError, done);
+        });
+      });
+
+      describe('validation errors for rider name', () => {
+        it('should give validation error for non-string rider name', (done) => {
+          const validationError = {
+            error_code: 'VALIDATION_ERROR',
+            message: 'Rider name must be a non empty string',
+          };
+          const propertyWithError = { rider_name: 12 };
+          assertRideValidationError(propertyWithError, validationError, done);
+        });
+
+        it('should give validation error for empty string rider name', (done) => {
+          const validationError = {
+            error_code: 'VALIDATION_ERROR',
+            message: 'Rider name must be a non empty string',
+          };
+          const propertyWithError = { rider_name: '' };
+          assertRideValidationError(propertyWithError, validationError, done);
+        });
+      });
+
+      describe('validation errors for driver name', () => {
+        it('should give validation error for non-string driver name', (done) => {
+          const validationError = {
+            error_code: 'VALIDATION_ERROR',
+            message: 'Rider name must be a non empty string',
+          };
+          const propertyWithError = { driver_name: 12 };
+          assertRideValidationError(propertyWithError, validationError, done);
+        });
+
+        it('should give validation error for empty string driver name', (done) => {
+          const validationError = {
+            error_code: 'VALIDATION_ERROR',
+            message: 'Rider name must be a non empty string',
+          };
+          const propertyWithError = { driver_name: '' };
+          assertRideValidationError(propertyWithError, validationError, done);
+        });
+      });
+
+      describe('validation errors for driver vehicle', () => {
+        it('should give validation error for non-string driver vehicle', (done) => {
+          const validationError = {
+            error_code: 'VALIDATION_ERROR',
+            message: 'Rider name must be a non empty string',
+          };
+          const propertyWithError = { driver_vehicle: 12 };
+          assertRideValidationError(propertyWithError, validationError, done);
+        });
+
+        it('should give validation error for empty string driver vehicle', (done) => {
+          const validationError = {
+            error_code: 'VALIDATION_ERROR',
+            message: 'Rider name must be a non empty string',
+          };
+          const propertyWithError = { driver_vehicle: '' };
+          assertRideValidationError(propertyWithError, validationError, done);
+        });
+      });
+    });
+  });
 });

--- a/tests/errorHandler.test.js
+++ b/tests/errorHandler.test.js
@@ -1,0 +1,27 @@
+const { errorHandler } = require('../src/lib/errorHandler');
+const assert = require('assert');
+
+class DummyResponse {
+  constructor() { }
+  status(code = 200) {
+    this.code = code;
+    return this;
+  }
+  send(body = {}) {
+    this.body = body;
+    return this;
+  }
+}
+
+describe('Custom error handler test', () => {
+  it('should call DummyResponse with status code of 500 and server error' +
+      ' message', (done) => {
+    const error = new Error('This is a test error');
+    const response = new DummyResponse();
+    errorHandler(error, null, response);
+    assert.strictEqual(response.code, 500);
+    assert.strictEqual(response.body.error_code, 'SERVER_ERROR');
+    assert.strictEqual(response.body.message, 'Unknown error');
+    done();
+  });
+});

--- a/tests/resources/dummyRides.json
+++ b/tests/resources/dummyRides.json
@@ -1,0 +1,29 @@
+[
+  {
+    "start_lat": 12,
+    "start_long": 14,
+    "end_lat": 19,
+    "end_long": 19,
+    "rider_name": "Joshua",
+    "driver_name": "John",
+    "driver_vehicle": "Truck"
+  },
+  {
+    "start_lat": -40,
+    "start_long": 8,
+    "end_lat": -19,
+    "end_long": 1,
+    "rider_name": "Herbert",
+    "driver_name": "Niece",
+    "driver_vehicle": "Car"
+  },
+  {
+    "start_lat": 50,
+    "start_long": 20,
+    "end_lat": 82,
+    "end_long": -1,
+    "rider_name": "New Rider",
+    "driver_name": "New Driver",
+    "driver_vehicle": "Tricycle"
+  }
+]


### PR DESCRIPTION
**Background**
> Please implement the following tooling:
> 1. `eslint` - for linting
> 2. `nyc` - for code coverage
> 3. `pre-push` - for git pre push hook running tests
> 4. `winston` - for logging

**Acceptance Criteria**
> 4. Create a separate pull request against `master` of your fork to increase code coverage to acceptable thresholds and merge it

**Description**
The PR adds more test cases to **api.test.js** and adds a new test file for **errorHandler.js**
![image](https://user-images.githubusercontent.com/22243493/97341425-01ec8f80-18c0-11eb-9975-badcd67c2864.png)

Scenarios covered by **api.test.js**
1. GET request to /rides
2. GET request to /rides/{id}
3. POST request to /rides
4. Validation errors on POST /rides
- Start latitude and longitude must be between -90 - 90 and -180 to 180 degrees respectively
- End latitude and longitude must be between -90 - 90 and -180 to 180 degrees respectively
- Rider name must be a non empty string (for rider)
- Rider name must be a non empty string (for driver)
- Rider name must be a non empty string (for vehicle)

**Problems encountered**
I noticed that the validation error messages being returned on rider, driver, and vehicle are all the same. I'm not quite sure if this was on purpose - and I've wanted to change that part, but I'll be sticking with the given code and instructions for the meantime, until we get on to #4 - Refactoring.
