### PR TITLE
Xendit #0007 - Refactoring Ride API

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -19,6 +19,7 @@ module.exports =  {
     "consistent-return": 0,
     "func-names": 0,
     "global-require": 0,
-    "no-restricted-globals": 0
+    "no-restricted-globals": 0,
+    "no-underscore-dangle": 0,
   }
 };

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -21,5 +21,6 @@ module.exports =  {
     "global-require": 0,
     "no-restricted-globals": 0,
     "no-underscore-dangle": 0,
+    "prefer-arrow-callback": 0,
   }
 };

--- a/index.js
+++ b/index.js
@@ -3,13 +3,11 @@ const port = 8010;
 const sqlite3 = require('sqlite3').verbose();
 
 const db = new sqlite3.Database(':memory:');
-
 const buildSchemas = require('./src/schemas');
 
 db.serialize(() => {
   buildSchemas(db);
 
   const app = require('./src/app')(db);
-
   app.listen(port, () => console.log(`App started and listening on port ${port}`));
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -369,6 +369,51 @@
       "integrity": "sha512-tsAQNx32a8CoFhjhijUIhI4kccIAgmGhy8LZMZgGfmXcpMbPRUqn5LWmgRttILi6yeGmBJd2xsPkFMs0PzgPCw==",
       "dev": true
     },
+    "@sinonjs/commons": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.8.1.tgz",
+      "integrity": "sha512-892K+kWUUi3cl+LlqEWIDrhvLgdL79tECi8JZUyq6IviKy/DNhuzCRlbHUjxK89f4ypPMMaFnFuR9Ie6DoIMsw==",
+      "dev": true,
+      "requires": {
+        "type-detect": "4.0.8"
+      }
+    },
+    "@sinonjs/fake-timers": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-6.0.1.tgz",
+      "integrity": "sha512-MZPUxrmFubI36XS1DI3qmI0YdN1gks62JtFZvxR67ljjSNCeK6U08Zx4msEWOXuofgqUt6zPHSi1H9fbjR/NRA==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^1.7.0"
+      }
+    },
+    "@sinonjs/formatio": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/formatio/-/formatio-5.0.1.tgz",
+      "integrity": "sha512-KaiQ5pBf1MpS09MuA0kp6KBQt2JUOQycqVG1NZXvzeaXe5LGFqAKueIS0bw4w0P9r7KuBSVdUk5QjXsUdu2CxQ==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^1",
+        "@sinonjs/samsam": "^5.0.2"
+      }
+    },
+    "@sinonjs/samsam": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-5.2.0.tgz",
+      "integrity": "sha512-CaIcyX5cDsjcW/ab7HposFWzV1kC++4HNsfnEdFJa7cP1QIuILAKV+BgfeqRXhcnSAc76r/Rh/O5C+300BwUIw==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^1.6.0",
+        "lodash.get": "^4.4.2",
+        "type-detect": "^4.0.8"
+      }
+    },
+    "@sinonjs/text-encoding": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/text-encoding/-/text-encoding-0.7.1.tgz",
+      "integrity": "sha512-+iTbntw2IZPb/anVDbypzfQa+ay64MW0Zo8aJ8gZPWMMK6/OubMVb6lUPMagqjOPnmtauXnFCACVl3O7ogjeqQ==",
+      "dev": true
+    },
     "@types/json5": {
       "version": "0.0.29",
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
@@ -2279,6 +2324,11 @@
         "sshpk": "^1.7.0"
       }
     },
+    "http-status-codes": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/http-status-codes/-/http-status-codes-2.1.4.tgz",
+      "integrity": "sha512-MZVIsLKGVOVE1KEnldppe6Ij+vmemMuApDfjhVSLzyYP+td0bREEYyAoIw9yFePoBXManCuBqmiNP5FqJS5Xkg=="
+    },
     "husky": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/husky/-/husky-4.3.0.tgz",
@@ -2962,6 +3012,12 @@
         "verror": "1.10.0"
       }
     },
+    "just-extend": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-4.1.1.tgz",
+      "integrity": "sha512-aWgeGFW67BP3e5181Ep1Fv2v8z//iBJfrvyTnq8wG86vEESwmonn1zPBJ0VfmT9CJq2FIT0VsETtrNFm2a+SHA==",
+      "dev": true
+    },
     "kuler": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/kuler/-/kuler-2.0.0.tgz",
@@ -3024,6 +3080,12 @@
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz",
       "integrity": "sha1-+wMJF/hqMTTlvJvsDWngAT3f7bI=",
+      "dev": true
+    },
+    "lodash.get": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+      "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=",
       "dev": true
     },
     "log-symbols": {
@@ -3273,6 +3335,36 @@
       "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
       "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
       "dev": true
+    },
+    "nise": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/nise/-/nise-4.0.4.tgz",
+      "integrity": "sha512-bTTRUNlemx6deJa+ZyoCUTRvH3liK5+N6VQZ4NIw90AgDXY6iPnsqplNFf6STcj+ePk0H/xqxnP75Lr0J0Fq3A==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^1.7.0",
+        "@sinonjs/fake-timers": "^6.0.0",
+        "@sinonjs/text-encoding": "^0.7.1",
+        "just-extend": "^4.0.2",
+        "path-to-regexp": "^1.7.0"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+          "dev": true
+        },
+        "path-to-regexp": {
+          "version": "1.8.0",
+          "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.8.0.tgz",
+          "integrity": "sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==",
+          "dev": true,
+          "requires": {
+            "isarray": "0.0.1"
+          }
+        }
+      }
     },
     "node-environment-flags": {
       "version": "1.0.5",
@@ -4521,6 +4613,44 @@
         }
       }
     },
+    "sinon": {
+      "version": "9.2.1",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-9.2.1.tgz",
+      "integrity": "sha512-naPfsamB5KEE1aiioaoqJ6MEhdUs/2vtI5w1hPAXX/UwvoPjXcwh1m5HiKx0HGgKR8lQSoFIgY5jM6KK8VrS9w==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^1.8.1",
+        "@sinonjs/fake-timers": "^6.0.1",
+        "@sinonjs/formatio": "^5.0.1",
+        "@sinonjs/samsam": "^5.2.0",
+        "diff": "^4.0.2",
+        "nise": "^4.0.4",
+        "supports-color": "^7.1.0"
+      },
+      "dependencies": {
+        "diff": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+          "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
     "slash": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
@@ -5139,6 +5269,12 @@
         "prelude-ls": "^1.2.1"
       }
     },
+    "type-detect": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+      "dev": true
+    },
     "type-fest": {
       "version": "0.8.1",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
@@ -5206,6 +5342,11 @@
         "spdx-correct": "^3.0.0",
         "spdx-expression-parse": "^3.0.0"
       }
+    },
+    "validator": {
+      "version": "13.1.17",
+      "resolved": "https://registry.npmjs.org/validator/-/validator-13.1.17.tgz",
+      "integrity": "sha512-zL5QBoemJ3jYFb2/j38y7ljhwYGXVLUp8H6W1nVxadnAOvUOytec+L7BHh1oBQ82/TzWXHd+GSaxUWp4lROkLg=="
     },
     "vary": {
       "version": "1.1.2",

--- a/package.json
+++ b/package.json
@@ -20,8 +20,10 @@
     "body-parser": "^1.19.0",
     "express": "^4.16.4",
     "faker": "^5.1.0",
+    "http-status-codes": "^2.1.4",
     "sqlite3": "^4.0.6",
     "swagger-ui-express": "^4.1.4",
+    "validator": "^13.1.17",
     "winston": "^3.3.3"
   },
   "devDependencies": {
@@ -31,6 +33,7 @@
     "husky": "^4.3.0",
     "mocha": "^6.1.4",
     "nyc": "^15.1.0",
+    "sinon": "^9.2.1",
     "supertest": "^4.0.2"
   },
   "husky": {

--- a/src/app.js
+++ b/src/app.js
@@ -9,158 +9,29 @@ const jsonParser = bodyParser.json();
 const swaggerUI = require('swagger-ui-express');
 const swaggerFile = require('./resources/api-v1-swagger.json');
 
+const { errorHandler } = require('./lib/errorHandler');
+const RideRepository = require('./modules/Ride/RideRepository');
+const RideController = require('./modules/Ride/RideController');
+const RideEntity = require('./modules/Ride/RideEntity');
 const { selectQuery, insertQuery } = require('./lib/databaseQuery');
 
-const { errorHandler } = require('./lib/errorHandler');
-
 module.exports = (db) => {
+  // Manually inject instances
+  const repository = new RideRepository(db, RideEntity, selectQuery, insertQuery);
+  const controller = new RideController(repository);
+
   app.get('/health', (req, res) => res.send('Healthy'));
 
   app.use('/api-documentation/v1', swaggerUI.serve, swaggerUI.setup(swaggerFile));
 
-  app.post('/rides', jsonParser, async (req, res, next) => {
-    const startLatitude = Number(req.body.start_lat);
-    const startLongitude = Number(req.body.start_long);
-    const endLatitude = Number(req.body.end_lat);
-    const endLongitude = Number(req.body.end_long);
-    const riderName = req.body.rider_name;
-    const driverName = req.body.driver_name;
-    const driverVehicle = req.body.driver_vehicle;
-
-    if (
-      startLatitude < -90
-        || startLatitude > 90
-        || startLongitude < -180
-        || startLongitude > 180
-    ) {
-      return res.send({
-        error_code: 'VALIDATION_ERROR',
-        message: 'Start latitude and longitude must be between -90 - 90 and -180 to 180 degrees respectively',
-      });
-    }
-
-    if (endLatitude < -90 || endLatitude > 90 || endLongitude < -180 || endLongitude > 180) {
-      return res.send({
-        error_code: 'VALIDATION_ERROR',
-        message: 'End latitude and longitude must be between -90 - 90 and -180 to 180 degrees respectively',
-      });
-    }
-
-    if (typeof riderName !== 'string' || riderName.length < 1) {
-      return res.send({
-        error_code: 'VALIDATION_ERROR',
-        message: 'Rider name must be a non empty string',
-      });
-    }
-
-    if (typeof driverName !== 'string' || driverName.length < 1) {
-      return res.send({
-        error_code: 'VALIDATION_ERROR',
-        message: 'Rider name must be a non empty string',
-      });
-    }
-
-    if (typeof driverVehicle !== 'string' || driverVehicle.length < 1) {
-      return res.send({
-        error_code: 'VALIDATION_ERROR',
-        message: 'Rider name must be a non empty string',
-      });
-    }
-
-    try {
-      const insertRideQuery = `
-        INSERT INTO Rides(startLat, startLong, endLat, endLong, riderName, driverName, driverVehicle) 
-        VALUES (?, ?, ?, ?, ?, ?, ?)
-      `;
-      const insertRideValues = [
-        req.body.start_lat,
-        req.body.start_long,
-        req.body.end_lat,
-        req.body.end_long,
-        req.body.rider_name,
-        req.body.driver_name,
-        req.body.driver_vehicle,
-      ];
-      const insertId = await insertQuery(db, insertRideQuery, insertRideValues);
-
-      const selectRideByIdQuery = 'SELECT * FROM Rides WHERE rideID = ?';
-      const selectRideByIdValues = [insertId];
-      const { results } = await selectQuery(db, selectRideByIdQuery, selectRideByIdValues);
-      res.send(results);
-    } catch (err) {
-      next(err);
-    }
+  app.post('/rides', jsonParser, function (req, res, next) {
+    controller.postRide(req, res, next);
   });
-
-  app.get('/rides', async (req, res, next) => {
-    const { page = 1, limit = 10 } = req.query;
-    if (isNaN(page) || page < 1 || isNaN(limit) || limit < 1) {
-      return res.send({
-        error_code: 'INVALID_PAGINATION_VALUES',
-        message: 'Pagination values should be a number and not be less than 1',
-      });
-    }
-
-    const offset = (page - 1) * limit;
-    const parsedPage = Number(page);
-    const nextUrl = `/rides?page=${parsedPage + 1}&limit=${limit}`;
-    const previousUrl = parsedPage === 1 ? null : `/rides?page=${parsedPage - 1}&limit=${limit}`;
-    try {
-      const selectRidesQuery = 'SELECT * FROM Rides LIMIT ? OFFSET ?';
-      const selectRidesValues = [limit, offset];
-      const {
-        results,
-      } = await selectQuery(db, selectRidesQuery, selectRidesValues);
-
-      if (results.length === 0) {
-        return res.send({
-          error_code: 'RIDES_NOT_FOUND_ERROR',
-          message: 'Could not find any rides',
-        });
-      }
-
-      const countRidesQuery = 'SELECT COUNT(*) as count FROM Rides';
-      const { results: countResult } = await selectQuery(db, countRidesQuery);
-      const [{ count: totalCount }] = countResult;
-
-      const hasNextPage = (page * limit) <= totalCount;
-      const response = {
-        next: hasNextPage ? nextUrl : null,
-        previous: previousUrl,
-        totalCount,
-        results,
-      };
-      res.send(response);
-    } catch (err) {
-      next(err);
-    }
+  app.get('/rides', function (req, res, next) {
+    controller.getRides(req, res, next);
   });
-
-  app.get('/rides/:id', async (req, res, next) => {
-    const { id } = req.params;
-    if (isNaN(id) || id < 0) {
-      return res.status(400).send({
-        error_code: 'INVALID_ID_PROVIDED',
-        message: 'ID should be a positive number greater than 0',
-      });
-    }
-
-    try {
-      const selectRideByIdQuery = 'SELECT * FROM Rides WHERE rideID = ?';
-      const selectRideByIdValues = [id];
-      const { results } = await selectQuery(db, selectRideByIdQuery, selectRideByIdValues);
-
-      if (results.length === 0) {
-        return res.send({
-          error_code: 'RIDES_NOT_FOUND_ERROR',
-          message: 'Could not find any rides',
-        });
-      }
-
-      res.send(results);
-    } catch (err) {
-      next(err);
-    }
+  app.get('/rides/:id', function (req, res, next) {
+    controller.getRide(req, res, next);
   });
 
   app.use(errorHandler);

--- a/src/lib/databaseQuery.js
+++ b/src/lib/databaseQuery.js
@@ -1,0 +1,57 @@
+const selectQuery = (db, query = '', values = []) => {
+  const results = [];
+
+  return new Promise((resolve, reject) => {
+    db.serialize(() => {
+      db.each(query, values, (err, row) => {
+        if (err) {
+          return reject(err);
+        }
+        results.push(row);
+      }, (accumulatedValuesErr, count) => {
+        if (accumulatedValuesErr) {
+          return reject(accumulatedValuesErr);
+        }
+
+        return resolve({ results, count });
+      });
+    });
+  });
+};
+
+const insertQuery = (db, query = '', values = []) => new Promise((resolve, reject) => {
+  // eslint-disable-next-line prefer-arrow-callback
+  db.run(query, values, function (insertErr) {
+    if (insertErr) {
+      return reject(insertErr);
+    }
+    resolve(this.lastID);
+  });
+});
+
+const deleteQuery = (db, query = '', values = []) => new Promise((resolve, reject) => {
+  // eslint-disable-next-line prefer-arrow-callback
+  db.run(query, values, function (deleteErr) {
+    if (deleteErr) {
+      return reject(deleteErr);
+    }
+    resolve();
+  });
+});
+
+const updateQuery = (db, query = '', values = []) => new Promise((resolve, reject) => {
+  // eslint-disable-next-line prefer-arrow-callback
+  db.run(query, values, function (updateErr) {
+    if (updateErr) {
+      return reject(updateErr);
+    }
+    resolve(this.changes);
+  });
+});
+
+module.exports = {
+  selectQuery,
+  insertQuery,
+  deleteQuery,
+  updateQuery,
+};

--- a/src/modules/Ride/RideController.js
+++ b/src/modules/Ride/RideController.js
@@ -1,0 +1,124 @@
+const isInteger = require('validator/lib/isInt');
+const isEmpty = require('validator/lib/isEmpty');
+const HttpStatusCodes = require('http-status-codes');
+
+class RideController {
+  constructor(rideRepositoryInstance) {
+    this.rideRepositoryInstance = rideRepositoryInstance;
+  }
+
+  async getRides(req, res, next) {
+    const { page = 1, limit = 10 } = req.query;
+    if (page && !isInteger(page, { min: 1 })) {
+      return res.status(HttpStatusCodes.BAD_REQUEST).send({
+        message: 'Page should be a number greater than 1',
+      });
+    }
+
+    if (limit && !isInteger(limit, { min: 1 })) {
+      return res.status(HttpStatusCodes.BAD_REQUEST).send({
+        message: 'Limit should be a number greater than 1',
+      });
+    }
+
+    try {
+      const results = await this.rideRepositoryInstance.getAll(page, limit);
+      const parsedPage = Number(page);
+      const nextUrl = `/rides?page=${parsedPage + 1}&limit=${limit}`;
+      const previousUrl = parsedPage === 1 ? null : `/rides?page=${parsedPage - 1}&limit=${limit}`;
+
+      const totalCount = await this.rideRepositoryInstance.getTotalCount();
+      const hasNextPage = (page * Number(limit)) <= totalCount;
+      const response = {
+        next: hasNextPage ? nextUrl : null,
+        previous: previousUrl,
+        totalCount,
+        results,
+      };
+      res.send(response);
+    } catch (err) {
+      next(err);
+    }
+  }
+
+  async getRide(req, res, next) {
+    const { id } = req.params;
+    if (isNaN(id) || id < 0) {
+      return res.status(HttpStatusCodes.BAD_REQUEST).send({
+        message: 'ID should be a positive number greater than 0',
+      });
+    }
+
+    try {
+      const results = await this.rideRepositoryInstance.getById(id);
+      res.send(results);
+    } catch (err) {
+      next(err);
+    }
+  }
+
+  async postRide(req, res, next) {
+    const stringPropertiesToCheck = [
+      'rider_name',
+      'driver_name',
+      'driver_vehicle',
+    ];
+    const missingStringProperty = stringPropertiesToCheck.find(
+      (propertyToCheck) => isEmpty(req.body[propertyToCheck] || ''),
+    );
+
+    if (missingStringProperty) {
+      return res.status(HttpStatusCodes.BAD_REQUEST).send({
+        message: `${missingStringProperty} must be a non-empty string`,
+      });
+    }
+
+    const numericPropertiesToCheck = [
+      'start_lat',
+      'start_long',
+      'end_lat',
+      'end_long',
+    ];
+    const missingNumericProperty = numericPropertiesToCheck.find(
+      (propertyToCheck) => isNaN(req.body[propertyToCheck]),
+    );
+
+    if (missingNumericProperty) {
+      return res.status(HttpStatusCodes.BAD_REQUEST).send({
+        message: `${missingNumericProperty} must be a numeric value`,
+      });
+    }
+
+    const startLat = Number(req.body.start_lat);
+    const startLong = Number(req.body.start_long);
+    const endLat = Number(req.body.end_lat);
+    const endLong = Number(req.body.end_long);
+    const riderName = req.body.rider_name;
+    const driverName = req.body.driver_name;
+    const driverVehicle = req.body.driver_vehicle;
+
+    try {
+      const rideEntity = {
+        startLat,
+        startLong,
+        endLat,
+        endLong,
+        riderName,
+        driverName,
+        driverVehicle,
+      };
+      const lastId = await this.rideRepositoryInstance.save(rideEntity);
+      const result = await this.rideRepositoryInstance.getById(lastId);
+      res.send(result);
+    } catch (err) {
+      if (err.message.includes('ModelError')) {
+        return res.status(HttpStatusCodes.BAD_REQUEST).send({
+          message: err.message,
+        });
+      }
+      next(err);
+    }
+  }
+}
+
+module.exports = RideController;

--- a/src/modules/Ride/RideController.js
+++ b/src/modules/Ride/RideController.js
@@ -9,13 +9,13 @@ class RideController {
 
   async getRides(req, res, next) {
     const { page = 1, limit = 10 } = req.query;
-    if (page && !isInteger(page, { min: 1 })) {
+    if (page && !isInteger(`${page}`, { min: 1 })) {
       return res.status(HttpStatusCodes.BAD_REQUEST).send({
         message: 'Page should be a number greater than 1',
       });
     }
 
-    if (limit && !isInteger(limit, { min: 1 })) {
+    if (limit && !isInteger(`${limit}`, { min: 1 })) {
       return res.status(HttpStatusCodes.BAD_REQUEST).send({
         message: 'Limit should be a number greater than 1',
       });
@@ -64,7 +64,7 @@ class RideController {
       'driver_vehicle',
     ];
     const missingStringProperty = stringPropertiesToCheck.find(
-      (propertyToCheck) => isEmpty(req.body[propertyToCheck] || ''),
+      (propertyToCheck) => isEmpty(req.body[propertyToCheck] ? `${req.body[propertyToCheck]}` : ''),
     );
 
     if (missingStringProperty) {

--- a/src/modules/Ride/RideEntity.js
+++ b/src/modules/Ride/RideEntity.js
@@ -1,0 +1,77 @@
+class RideEntity {
+  constructor() {
+    this._rideID = null;
+    this._startLat = null;
+    this._startLong = null;
+    this._endLat = null;
+    this._endLong = null;
+    this._riderName = null;
+    this._driverName = null;
+    this._driverVehicle = null;
+    this._created = null;
+  }
+
+  rideId(id) {
+    this._rideID = id;
+    return this;
+  }
+
+  startLat(startlat) {
+    if (startlat < -90 || startlat > 90) {
+      throw new Error('ModelError: startLat should be not be greater than 90 or less'
+          + ' than -90');
+    }
+    this._startLat = startlat;
+    return this;
+  }
+
+  startLong(startlong) {
+    if (startlong < -180 || startlong > 180) {
+      throw new Error('ModelError: startLong should be not be greater than 180 or less'
+          + ' than -180');
+    }
+    this._startLong = startlong;
+    return this;
+  }
+
+  endLat(endlat) {
+    if (endlat < -90 || endlat > 90) {
+      throw new Error('ModelError: endlat should be not be greater than 90 or'
+          + ' less'
+          + ' than -90');
+    }
+    this._endLat = endlat;
+    return this;
+  }
+
+  endLong(endlong) {
+    if (endlong < -180 || endlong > 180) {
+      throw new Error('ModelError: endLong should be not be greater than 180 or less'
+          + ' than -180');
+    }
+    this._endLong = endlong;
+    return this;
+  }
+
+  riderName(ridername) {
+    this._riderName = ridername;
+    return this;
+  }
+
+  driverName(drivername) {
+    this._driverName = drivername;
+    return this;
+  }
+
+  driverVehicle(drivervehicle) {
+    this._driverVehicle = drivervehicle;
+    return this;
+  }
+
+  created(createdDate) {
+    this._created = createdDate;
+    return this;
+  }
+}
+
+module.exports = RideEntity;

--- a/src/modules/Ride/RideRepository.js
+++ b/src/modules/Ride/RideRepository.js
@@ -1,0 +1,68 @@
+class RideRepository {
+  constructor(db, RideEntity, selectQuery, insertQuery) {
+    this.db = db;
+    this.RideEntity = RideEntity;
+    this.selectQuery = selectQuery;
+    this.insertQuery = insertQuery;
+  }
+
+  async getById(id) {
+    const selectRideByIdQuery = 'SELECT * FROM Rides WHERE rideID = ?';
+    const selectRideByIdValues = [id];
+    const { results } = await this.selectQuery(this.db, selectRideByIdQuery, selectRideByIdValues);
+
+    return results;
+  }
+
+  async getAll(page = 1, limit = 10) {
+    const selectRidesQuery = 'SELECT * FROM Rides LIMIT ? OFFSET ?';
+    const offset = (page - 1) * limit;
+    const selectRidesValues = [limit, offset];
+    const {
+      results,
+    } = await this.selectQuery(this.db, selectRidesQuery, selectRidesValues);
+
+    return results;
+  }
+
+  async getTotalCount() {
+    const countRidesQuery = 'SELECT COUNT(*) as count FROM Rides';
+    const { results: countResult } = await this.selectQuery(this.db, countRidesQuery);
+    const [{ count: totalCount }] = countResult;
+
+    return totalCount;
+  }
+
+  async save(rideEntity) {
+    const rideInstance = new this.RideEntity();
+    // Use RiderEntity to verify model logic, e.g: lat should be between
+    // 90, etc.
+    rideInstance
+      .startLat(rideEntity.startLat)
+      .startLong(rideEntity.startLong)
+      .endLat(rideEntity.endLat)
+      .endLong(rideEntity.endLong)
+      .riderName(rideEntity.riderName)
+      .driverName(rideEntity.driverName)
+      .driverVehicle(rideEntity.driverVehicle);
+
+    const insertRideQuery = `
+        INSERT INTO Rides(startLat, startLong, endLat, endLong, riderName, driverName, driverVehicle) 
+        VALUES (?, ?, ?, ?, ?, ?, ?)
+      `;
+    const insertRideValues = [
+      rideEntity.startLat,
+      rideEntity.startLong,
+      rideEntity.endLat,
+      rideEntity.endLong,
+      rideEntity.riderName,
+      rideEntity.driverName,
+      rideEntity.driverVehicle,
+    ];
+    const insertId = await this.insertQuery(this.db, insertRideQuery, insertRideValues);
+
+    return insertId;
+  }
+}
+
+module.exports = RideRepository;

--- a/src/resources/api-v1-swagger.json
+++ b/src/resources/api-v1-swagger.json
@@ -216,6 +216,9 @@
               "$ref": "#/definitions/PaginatedRideOutput"
             },
             "description": "Successful operation"
+          },
+          "400": {
+            "description": "Validation error, check that page and limit are numeric values"
           }
         }
       },
@@ -243,6 +246,9 @@
         "responses": {
           "200": {
             "description": "Successfully added new ride"
+          },
+          "400": {
+            "description": "Validation error, check that required fields are present"
           }
         }
       }
@@ -274,6 +280,9 @@
               }
             },
             "description": "Successful operation"
+          },
+          "400": {
+            "description": "Validation error, check that id parameter is numeric and greater than 0"
           }
         }
       }

--- a/tests/DummyResponse.js
+++ b/tests/DummyResponse.js
@@ -1,0 +1,13 @@
+class DummyResponse {
+  constructor() { }
+  status(code = 200) {
+    this.code = code;
+    return this;
+  }
+  send(body = {}) {
+    this.body = body;
+    return this;
+  }
+}
+
+module.exports = DummyResponse;

--- a/tests/RideController.test.js
+++ b/tests/RideController.test.js
@@ -1,0 +1,234 @@
+const RideController = require('../src/modules/Ride/RideController');
+const DummyResponse = require('./DummyResponse');
+const assert = require('assert');
+const HttpStatusCodes = require('http-status-codes');
+
+describe('RideController test cases', () => {
+  it('should return mock data when calling getRides', async () => {
+    const mockData = [
+      {
+        "rideID": 4,
+        "startLat": 12,
+        "startLong": 14,
+        "endLat": 19,
+        "endLong": 19,
+        "riderName": "Joshua",
+        "driverName": "John",
+        "driverVehicle": "Truck",
+        "created": "2020-10-28 15:01:11"
+      },
+      {
+        "rideID": 5,
+        "startLat": 12,
+        "startLong": 14,
+        "endLat": 19,
+        "endLong": 19,
+        "riderName": "Joshua",
+        "driverName": "John",
+        "driverVehicle": "Truck",
+        "created": "2020-10-28 15:01:11"
+      },
+      {
+        "rideID": 6,
+        "startLat": 12,
+        "startLong": 14,
+        "endLat": 19,
+        "endLong": 19,
+        "riderName": "Joshua",
+        "driverName": "John",
+        "driverVehicle": "Truck",
+        "created": "2020-10-28 15:01:12"
+      }
+    ];
+    const rideRepositoryMock = {
+      getAll: async () => mockData,
+      getTotalCount: async () => mockData.length,
+    };
+    const rideControllerInstance = new RideController(rideRepositoryMock);
+
+    const requestMock = {
+      query: {
+        page: '1',
+        limit: '10',
+      },
+    };
+    const responseMock = new DummyResponse();
+    await rideControllerInstance.getRides(requestMock, responseMock, null);
+    const { next, previous, results } = responseMock.body;
+    assert.strictEqual(next, null);
+    assert.strictEqual(previous, null);
+    assert.deepStrictEqual(results, mockData);
+  });
+
+  it('should throw validation when calling getRides with invalid limit value', async () => {
+    const rideRepositoryMock = {};
+    const rideControllerInstance = new RideController(rideRepositoryMock);
+
+    const requestMock = {
+      query: {
+        page: '1',
+        limit: 'hello',
+      },
+    };
+    const responseMock = new DummyResponse();
+    await rideControllerInstance.getRides(requestMock, responseMock, null);
+    assert.deepStrictEqual(responseMock.body, { message: 'Limit should be a' +
+          ' number greater than 1' });
+    assert.strictEqual(responseMock.code, HttpStatusCodes.BAD_REQUEST);
+  });
+
+  it('should throw validation when calling getRides with invalid page value', async () => {
+    const rideRepositoryMock = {};
+    const rideControllerInstance = new RideController(rideRepositoryMock);
+
+    const requestMock = {
+      query: {
+        page: 'hello',
+        limit: '1',
+      },
+    };
+    const responseMock = new DummyResponse();
+    await rideControllerInstance.getRides(requestMock, responseMock, null);
+    assert.deepStrictEqual(responseMock.body, { message: 'Page should be a' +
+          ' number greater than 1' });
+    assert.strictEqual(responseMock.code, HttpStatusCodes.BAD_REQUEST);
+  });
+
+  it('should return mock data when calling getRide', async () => {
+    const mockData = [
+      {
+        "rideID": 4,
+        "startLat": 12,
+        "startLong": 14,
+        "endLat": 19,
+        "endLong": 19,
+        "riderName": "Joshua",
+        "driverName": "John",
+        "driverVehicle": "Truck",
+        "created": "2020-10-28 15:01:11"
+      }
+    ];
+    const rideRepositoryMock = {
+      getById: async () => mockData,
+    };
+    const rideControllerInstance = new RideController(rideRepositoryMock);
+    const requestMock = {
+      params: {
+        id: 4,
+      },
+    };
+    const responseMock = new DummyResponse();
+    await rideControllerInstance.getRide(requestMock, responseMock, null);
+    assert.deepStrictEqual(responseMock.body, mockData);
+  });
+
+  it('should throw validation error when calling getRide with invalid id', async () => {
+    const rideRepositoryMock = {
+      getById: async () => {},
+    };
+    const rideControllerInstance = new RideController(rideRepositoryMock);
+    const requestMock = {
+      params: {
+        id: 'hello',
+      },
+    };
+    const responseMock = new DummyResponse();
+    await rideControllerInstance.getRide(requestMock, responseMock, null);
+    assert.deepStrictEqual(responseMock.body, { message: 'ID should be a positive number greater than 0'});
+    assert.strictEqual(responseMock.code, HttpStatusCodes.BAD_REQUEST);
+  });
+
+  it('should return mock last insert id when calling postRide', async () => {
+    const mockData = {
+      "start_lat": 90,
+      "start_long": 180,
+      "end_lat": -90,
+      "end_long": -180,
+      "rider_name": "Joshua",
+      "driver_name": "John",
+      "driver_vehicle": "Truck"
+    };
+    const rideRepositoryMock = {
+      save: async () => 4,
+      getById: async () => mockData,
+    };
+    const rideControllerInstance = new RideController(rideRepositoryMock);
+    const requestMock = {
+      body: mockData,
+    };
+    const responseMock = new DummyResponse();
+    await rideControllerInstance.postRide(requestMock, responseMock, null);
+    assert.strictEqual(responseMock.body, mockData);
+  });
+
+  it('should validation error for error thrown by RideEntity', async () => {
+    const mockData = {
+      "start_lat": 90,
+      "start_long": 180,
+      "end_lat": -90,
+      "end_long": -180,
+      "rider_name": "Joshua",
+      "driver_name": "John",
+      "driver_vehicle": "Truck"
+    };
+    const errorMessage = 'ModelError: startLat should be not be greater than 90 or less'
+        + ' than -90';
+    const rideRepositoryMock = {
+      save: async () => {
+        throw new Error(errorMessage);
+      },
+      getById: async () => mockData,
+    };
+    const rideControllerInstance = new RideController(rideRepositoryMock);
+    const requestMock = {
+      body: mockData,
+    };
+    const responseMock = new DummyResponse();
+    await rideControllerInstance.postRide(requestMock, responseMock, null);
+    assert.strictEqual(responseMock.code, HttpStatusCodes.BAD_REQUEST);
+    assert.deepStrictEqual(responseMock.body, { message: errorMessage });
+  });
+
+  it('should give validation error when calling postRide with missing' +
+      ' rider_name', async () => {
+    const mockData = {
+      "start_lat": 90,
+      "start_long": 180,
+      "end_lat": -90,
+      "end_long": -180,
+      "driver_name": "John",
+      "driver_vehicle": "Truck"
+    };
+    const rideRepositoryMock = {};
+    const rideControllerInstance = new RideController(rideRepositoryMock);
+    const requestMock = {
+      body: mockData,
+    };
+    const responseMock = new DummyResponse();
+    await rideControllerInstance.postRide(requestMock, responseMock, null);
+    assert.strictEqual(responseMock.code, HttpStatusCodes.BAD_REQUEST);
+    assert.deepStrictEqual(responseMock.body, { message: 'rider_name must be' +
+          ' a non-empty string'});
+  });
+
+  it('should give validation error when calling postRide with missing' +
+      ' start_lat', async () => {
+    const mockData = {
+      "start_long": 180,
+      "end_lat": -90,
+      "end_long": -180,
+      "driver_name": "John",
+      "driver_vehicle": "Truck",
+      "rider_name": "Robert",
+    };
+    const rideRepositoryMock = {};
+    const rideControllerInstance = new RideController(rideRepositoryMock);
+    const requestMock = {
+      body: mockData,
+    };
+    const responseMock = new DummyResponse();
+    await rideControllerInstance.postRide(requestMock, responseMock, null);
+    assert.strictEqual(responseMock.code, HttpStatusCodes.BAD_REQUEST);
+    assert.deepStrictEqual(responseMock.body, { message: 'start_lat must be a numeric value'});
+  });
+});

--- a/tests/RideEntity.test.js
+++ b/tests/RideEntity.test.js
@@ -1,0 +1,116 @@
+const RideEntity = require('../src/modules/Ride/RideEntity');
+const assert = require('assert');
+
+describe('RideEntity test cases', () => {
+  it('should be initialized with all null values', () => {
+    const rideInstance = new RideEntity();
+    assert.strictEqual(rideInstance._rideID , null);
+    assert.strictEqual(rideInstance._startLat , null);
+    assert.strictEqual(rideInstance._startLong , null);
+    assert.strictEqual(rideInstance._endLat , null);
+    assert.strictEqual(rideInstance._endLong , null);
+    assert.strictEqual(rideInstance._riderName , null);
+    assert.strictEqual(rideInstance._driverName , null);
+    assert.strictEqual(rideInstance._driverVehicle , null);
+    assert.strictEqual(rideInstance._created , null);
+  });
+
+  it('should be initialized with given values', () => {
+    const dummyRide = {
+      "rideID": 5,
+      "startLat": 12,
+      "startLong": 14,
+      "endLat": 19,
+      "endLong": 19,
+      "riderName": "Joshua",
+      "driverName": "John",
+      "driverVehicle": "Truck",
+      "created": "2020-10-28 15:01:11"
+    };
+    const rideInstance = new RideEntity();
+    rideInstance
+      .rideId(dummyRide.rideID)
+      .startLat(dummyRide.startLat)
+      .startLong(dummyRide.startLong)
+      .endLat(dummyRide.endLat)
+      .endLong(dummyRide.endLong)
+      .riderName(dummyRide.riderName)
+      .driverName(dummyRide.driverName)
+      .driverVehicle(dummyRide.driverVehicle)
+      .created(dummyRide.created)
+    assert.strictEqual(rideInstance._rideID , dummyRide.rideID);
+    assert.strictEqual(rideInstance._startLat , dummyRide.startLat);
+    assert.strictEqual(rideInstance._startLong , dummyRide.startLong);
+    assert.strictEqual(rideInstance._endLat , dummyRide.endLat);
+    assert.strictEqual(rideInstance._endLong , dummyRide.endLong);
+    assert.strictEqual(rideInstance._riderName , dummyRide.riderName);
+    assert.strictEqual(rideInstance._driverName , dummyRide.driverName);
+    assert.strictEqual(rideInstance._driverVehicle , dummyRide.driverVehicle);
+    assert.strictEqual(rideInstance._created , dummyRide.created);
+  });
+
+  it('should throw an error if startLat is less than -90', () => {
+    try {
+      const rideInstance = new RideEntity();
+      rideInstance.startLat(-91);
+      assert.fail('startLat should throw an error');
+    } catch (err) {}
+  })
+
+  it('should throw an error if startLat is more than 90', () => {
+    try {
+      const rideInstance = new RideEntity();
+      rideInstance.startLat(91);
+      assert.fail('startLat should throw an error');
+    } catch (err) {}
+  })
+
+  it('should throw an error if endLat is less than -90', () => {
+    try {
+      const rideInstance = new RideEntity();
+      rideInstance.endLat(-91);
+      assert.fail('endLat should throw an error');
+    } catch (err) {}
+  })
+
+  it('should throw an error if endLat is more than 90', () => {
+    try {
+      const rideInstance = new RideEntity();
+      rideInstance.endLat(91);
+      assert.fail('endLat should throw an error');
+    } catch (err) {}
+  })
+
+  //
+  it('should throw an error if startLong is less than -180', () => {
+    try {
+      const rideInstance = new RideEntity();
+      rideInstance.startLong(-181);
+      assert.fail('startLong should throw an error');
+    } catch (err) {}
+  })
+
+  it('should throw an error if startLong is more than 180', () => {
+    try {
+      const rideInstance = new RideEntity();
+      rideInstance.startLong(181);
+      assert.fail('startLong should throw an error');
+    } catch (err) {}
+  })
+
+  it('should throw an error if endLong is less than -181', () => {
+    try {
+      const rideInstance = new RideEntity();
+      rideInstance.endLong(-181);
+      assert.fail('endLong should throw an error');
+    } catch (err) {}
+  })
+
+  it('should throw an error if endLong is more than 181', () => {
+    try {
+      const rideInstance = new RideEntity();
+      rideInstance.endLong(181);
+      assert.fail('endLong should throw an error');
+    } catch (err) {}
+  })
+});

--- a/tests/RideRepository.test.js
+++ b/tests/RideRepository.test.js
@@ -1,0 +1,96 @@
+const RideRepository = require('../src/modules/Ride/RideRepository');
+const RideEntity = require('../src/modules/Ride/RideEntity');
+
+const assert = require('assert');
+
+describe('RideRepository test cases', () => {
+  it('should return mock data when calling getById', async () => {
+    const mockData = [{
+      "rideID": 5,
+      "startLat": 12,
+      "startLong": 14,
+      "endLat": 19,
+      "endLong": 19,
+      "riderName": "Joshua",
+      "driverName": "John",
+      "driverVehicle": "Truck",
+      "created": "2020-10-28 15:01:11"
+    }];
+
+    const selectQuery = async () => ({ results: mockData });
+    const rideRepository = new RideRepository(null, null, selectQuery, null);
+    const results = await rideRepository.getById(12);
+    assert.deepStrictEqual(results, mockData);
+  });
+
+  it('should return mock data when calling getAll', async () => {
+    const mockData = [
+      {
+        "rideID": 4,
+        "startLat": 12,
+        "startLong": 14,
+        "endLat": 19,
+        "endLong": 19,
+        "riderName": "Joshua",
+        "driverName": "John",
+        "driverVehicle": "Truck",
+        "created": "2020-10-28 15:01:11"
+      },
+      {
+        "rideID": 5,
+        "startLat": 12,
+        "startLong": 14,
+        "endLat": 19,
+        "endLong": 19,
+        "riderName": "Joshua",
+        "driverName": "John",
+        "driverVehicle": "Truck",
+        "created": "2020-10-28 15:01:11"
+      },
+      {
+        "rideID": 6,
+        "startLat": 12,
+        "startLong": 14,
+        "endLat": 19,
+        "endLong": 19,
+        "riderName": "Joshua",
+        "driverName": "John",
+        "driverVehicle": "Truck",
+        "created": "2020-10-28 15:01:12"
+      }
+    ];
+
+    const selectQuery = async () => ({ results: mockData });
+    const rideRepository = new RideRepository(null, null, selectQuery, null);
+    const results = await rideRepository.getAll();
+    assert.deepStrictEqual(results, mockData);
+  });
+
+  it('should return mock total count when calling getTotalCount', async () => {
+    const results = [
+      {
+        count: 15,
+      }
+    ];
+    const selectQuery = async () => ({ results });
+    const rideRepository = new RideRepository(null, null, selectQuery, null);
+    const totalCount = await rideRepository.getTotalCount();
+    assert.deepStrictEqual(totalCount, 15);
+  });
+
+  it('should return mock last id when calling save', async () => {
+    const dummyRide = {
+      "startLat": 12,
+      "startLong": 14,
+      "endLat": 19,
+      "endLong": 19,
+      "riderName": "Joshua",
+      "driverName": "John",
+      "driverVehicle": "Truck",
+    };
+    const insertQuery = async () => 5;
+    const rideRepository = new RideRepository(null, RideEntity, null, insertQuery);
+    const insertId = await rideRepository.save(dummyRide);
+    assert.deepStrictEqual(insertId, 5);
+  });
+});

--- a/tests/databaseQuery.test.js
+++ b/tests/databaseQuery.test.js
@@ -1,0 +1,105 @@
+const sinon = require('sinon');
+const assert=  require('assert');
+
+const sqlite3 = require('sqlite3').verbose();
+const db = new sqlite3.Database(':memory:');
+const buildSchemas = require('../src/schemas');
+
+const {
+  selectQuery, insertQuery, deleteQuery, updateQuery,
+} = require('../src/lib/databaseQuery');
+
+describe('Database query utility tests', () => {
+  describe('Stub tests not calling actual db', () => {
+    it('selectQuery should call db.serialize and db.each once', (done) => {
+      const db = {
+        serialize: () => {},
+        each: () => {},
+        run: () => {},
+      };
+      const each = sinon.stub(db, 'each');
+      const serialize = sinon.stub(db, 'serialize').callsFake(() => db.each());
+      selectQuery(db);
+      each.restore();
+      sinon.assert.calledOnce(each);
+      sinon.assert.calledOnce(serialize);
+      done();
+    });
+
+    it('insertQuery should call db.run once', (done) => {
+      const db = {
+        run: () => {},
+      };
+      const run = sinon.stub(db, 'run');
+      insertQuery(db);
+      run.restore();
+      sinon.assert.calledOnce(run);
+      done();
+    });
+
+    it('updateQuery should call db.run once', (done) => {
+      const db = {
+        run: () => {},
+      };
+      const run = sinon.stub(db, 'run');
+      updateQuery(db);
+      run.restore();
+      sinon.assert.calledOnce(run);
+      done();
+    });
+
+    it('deleteQuery should call db.run once', (done) => {
+      const db = {
+        run: () => {},
+      };
+      const run = sinon.stub(db, 'run');
+      deleteQuery(db);
+      run.restore();
+      sinon.assert.calledOnce(run);
+      done();
+    });
+  });
+
+  describe('Tests calling actual db', () => {
+    before((done) => {
+      db.serialize((err) => {
+        if (err) {
+          return done(err);
+        }
+
+        buildSchemas(db);
+
+        done();
+      });
+    });
+
+    it('selectQuery should throw an error with invalid query', async () => {
+      try {
+        await selectQuery(db, 'testtesttest');
+        assert.fail('selectQuery should throw an error');
+      } catch (error) {}
+    });
+
+    it('updateQuery should throw an error with invalid query', async () => {
+      try {
+        await updateQuery(db, 'testtesttest');
+        assert.fail('updateQuery should throw an error');
+      } catch (error) {}
+    });
+
+    it('deleteQuery should throw an error with invalid query', async () => {
+      try {
+        await deleteQuery(db, 'testtesttest');
+        assert.fail('deleteQuery should throw an error');
+      } catch (error) {}
+    });
+
+    it('insertQuery should throw an error with invalid query', async () => {
+      try {
+        await insertQuery(db, 'testtesttest');
+        assert.fail('insertQuery should throw an error');
+      } catch (error) {}
+    });
+  });
+});
+

--- a/tests/errorHandler.test.js
+++ b/tests/errorHandler.test.js
@@ -1,17 +1,6 @@
 const { errorHandler } = require('../src/lib/errorHandler');
 const assert = require('assert');
-
-class DummyResponse {
-  constructor() { }
-  status(code = 200) {
-    this.code = code;
-    return this;
-  }
-  send(body = {}) {
-    this.body = body;
-    return this;
-  }
-}
+const DummyResponse = require('./DummyResponse');
 
 describe('Custom error handler test', () => {
   it('should call DummyResponse with status code of 500 and server error' +


### PR DESCRIPTION
**Background**
> Please implement the following refactors of the code:
> 1. Convert callback style code to use `async/await`
> 2. Reduce complexity at top level control flow logic and move logic down and test independently
> 3. **[BONUS]** Split between functional and imperative function and test independently

**Acceptance Criteria**
> 1. A pull request against `master` of your fork for each of the refactors above with:
>     1. Code changes
>     2. Tests

**Description**
The PR converts callback code to **async/await**, as well as:
- Reducing the coupling between the modules. Modules now have their own respective layer (Controller and Repository). I did not find the need to add a service layer for the mean time, as it doesn't fit much the use case of the example.
- Overdid it a bit by also **changing the returned status code for validation errors**. Previously, they returned 200 OK - in which a 400 code would have been better.
- Unit testing for independent modules
- Updated documentation to match changes on http status codes